### PR TITLE
Added support for time ranges for Transactions

### DIFF
--- a/libfintx/Main.cs
+++ b/libfintx/Main.cs
@@ -122,12 +122,16 @@ namespace libfintx
         /// Transactions
         /// </returns>
         public static string Transactions(string Account, int BLZ, string IBAN, string BIC, string URL, int HBCIVersion,
-            string UserID, string PIN, bool Anonymous)
+            string UserID, string PIN, bool Anonymous, DateTime? startDate = null, DateTime? endDate = null)
         {
             if (Transaction.INI(BLZ, URL, HBCIVersion, UserID, PIN, Anonymous) == true)
             {
+
+                var startDateStr = startDate?.ToString("yyyyMMdd");
+                var endDateStr = endDate?.ToString("yyyyMMdd");
+
                 // Success
-                var BankCode = Transaction.HKKAZ(Account, BLZ, IBAN, BIC, URL, HBCIVersion, UserID, PIN, null, null);
+                var BankCode = Transaction.HKKAZ(Account, BLZ, IBAN, BIC, URL, HBCIVersion, UserID, PIN, startDateStr, endDateStr, null);
 
                 var Transactions = ":20:STARTUMS" + Helper.Parse_String(BankCode, ":20:STARTUMS", "'HNSHA");
 
@@ -141,7 +145,7 @@ namespace libfintx
 
                     var Startpoint = Helper.Parse_String(BankCode, "vor:", "'");
 
-                    var BankCode_ = Transaction.HKKAZ(Account, BLZ, IBAN, BIC, URL, HBCIVersion, UserID, PIN, null, Startpoint);
+                    var BankCode_ = Transaction.HKKAZ(Account, BLZ, IBAN, BIC, URL, HBCIVersion, UserID, PIN, startDateStr, endDateStr, Startpoint);
 
                     var Transactions_ = ":20:STARTUMS" + Helper.Parse_String(BankCode_, ":20:STARTUMS", "'HNSHA");
 

--- a/libfintx/Transactions/HKKAZ.cs
+++ b/libfintx/Transactions/HKKAZ.cs
@@ -30,7 +30,7 @@ namespace libfintx
         /// <summary>
         /// Transactions
         /// </summary>
-        public static string Init_HKKAZ(string Konto, int BLZ, string IBAN, string BIC, string URL, int HBCIVersion, string UserID, string PIN, string FromDate, string Startpoint)
+        public static string Init_HKKAZ(string Konto, int BLZ, string IBAN, string BIC, string URL, int HBCIVersion, string UserID, string PIN, string FromDate, string ToDate, string Startpoint)
         {
             Log.Write("Starting job HKKAZ: Request transactions");
 
@@ -58,16 +58,16 @@ namespace libfintx
                 if (String.IsNullOrEmpty(Startpoint))
                 {
                     if (Convert.ToInt16(Segment.HKKAZ) < 7)
-                        segments = "HKKAZ:" + SEGNUM.SETVal(3) + ":" + Segment.HKKAZ + "+" + Konto + "::280:" + BLZ + "+N+" + FromDate + "'";
+                        segments = "HKKAZ:" + SEGNUM.SETVal(3) + ":" + Segment.HKKAZ + "+" + Konto + "::280:" + BLZ + "+N+" + FromDate + "+" + ToDate + "'";
                     else
-                        segments = "HKKAZ:" + SEGNUM.SETVal(3) + ":" + Segment.HKKAZ + "+" + IBAN + ":" + BIC + ":" + Konto + "::280:" + BLZ + "+N+" + FromDate + "'";
+                        segments = "HKKAZ:" + SEGNUM.SETVal(3) + ":" + Segment.HKKAZ + "+" + IBAN + ":" + BIC + ":" + Konto + "::280:" + BLZ + "+N+" + FromDate + "+" + ToDate + "'";
                 }
                 else
                 {
                     if (Convert.ToInt16(Segment.HKKAZ) < 7)
-                        segments = "HKKAZ:" + SEGNUM.SETVal(3) + ":" + Segment.HKKAZ + "+" + Konto + "::280:" + BLZ + "+N+" + FromDate + "+++" + Startpoint + "'";
+                        segments = "HKKAZ:" + SEGNUM.SETVal(3) + ":" + Segment.HKKAZ + "+" + Konto + "::280:" + BLZ + "+N+" + FromDate + "+" + ToDate + "++" + Startpoint + "'";
                     else
-                        segments = "HKKAZ:" + SEGNUM.SETVal(3) + ":" + Segment.HKKAZ + "+" + IBAN + ":" + BIC + ":" + Konto + "::280:" + BLZ + "+N+" + FromDate + "+++" + Startpoint + "'";
+                        segments = "HKKAZ:" + SEGNUM.SETVal(3) + ":" + Segment.HKKAZ + "+" + IBAN + ":" + BIC + ":" + Konto + "::280:" + BLZ + "+N+" + FromDate + "+" + ToDate + "++" + Startpoint + "'";
                 }
             }
 

--- a/libfintx/Transactions/Transaction.cs
+++ b/libfintx/Transactions/Transaction.cs
@@ -54,9 +54,9 @@ namespace libfintx
         }
 
         public static string HKKAZ(string Konto, int BLZ, string IBAN, string BIC, string URL, int HBCIVersion, string UserID,
-            string PIN, string FromDate, string Startpoint)
+            string PIN, string FromDate, string ToDate, string Startpoint)
         {
-            return Init_HKKAZ(Konto, BLZ, IBAN, BIC, URL, HBCIVersion, UserID, PIN, FromDate, Startpoint);
+            return Init_HKKAZ(Konto, BLZ, IBAN, BIC, URL, HBCIVersion, UserID, PIN, FromDate, ToDate, Startpoint);
         }
 
         public static string HKCCS(int BLZ, string Accountholder, string AccountholderIBAN, string AccountholderBIC, string Receiver,


### PR DESCRIPTION
This PR adds support for requesting Transactions with start- or with start-
and enddate. Date parameters are null by default(-parameter), so this changes can be
merged, without affecting current implementations.