### PR TITLE
Add options to avoid writing any files to disk

### DIFF
--- a/libfintx/Debugging/Debug.cs
+++ b/libfintx/Debugging/Debug.cs
@@ -31,7 +31,10 @@ namespace libfintx
 
         public static void Write(string Message)
         {
-            Console.WriteLine("[" + DateTime.Now + "]" + " " + Message + Environment.NewLine);
+            if (Enabled)
+            {
+                Console.WriteLine("[" + DateTime.Now + "]" + " " + Message + Environment.NewLine);
+            }
         }
     }
 }

--- a/libfintx/Helper/Helper.cs
+++ b/libfintx/Helper/Helper.cs
@@ -106,15 +106,7 @@ namespace libfintx
             try
             {
                 String[] values = Message.Split('\'');
-
-                var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-                var dir = Path.Combine(documents, Program.Buildname);
-
-				if (!Directory.Exists(dir))
-				{
-					Directory.CreateDirectory(dir);
-				}
-
+                                
                 List<string> msg = new List<string>();
 
                 foreach (var item in values)
@@ -127,42 +119,53 @@ namespace libfintx
                 string bpd = "HIBPA" + Parse_String(msg_, "HIBPA", "\r\n" + "HIUPA");
                 string upd = "HIUPA" + Parse_String(msg_, "HIUPA", "\r\n" + "HNSHA");
 
-				// BPD
-				dir = Path.Combine(dir, "BPD");
+                if (Trace.Enabled) {
 
-                if (!Directory.Exists(dir))
-                {
-                    Directory.CreateDirectory(dir);
+                    var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+                    var dir = Path.Combine(documents, Program.Buildname);
+
+                    if (!Directory.Exists(dir))
+                    {
+                        Directory.CreateDirectory(dir);
+                    }
+
+                    // BPD
+                    dir = Path.Combine(dir, "BPD");
+
+                    if (!Directory.Exists(dir))
+                    {
+                        Directory.CreateDirectory(dir);
+                    }
+
+                    if (!File.Exists(Path.Combine(dir, "280_" + BLZ + ".bpd")))
+                    {
+                        using (File.Create(Path.Combine(dir, "280_" + BLZ + ".bpd")))
+                        { };
+
+                        File.WriteAllText(Path.Combine(dir, "280_" + BLZ + ".bpd"), bpd);
+                    }
+                    else
+                        File.WriteAllText(Path.Combine(dir, "280_" + BLZ + ".bpd"), bpd);
+               
+                    // UPD
+                    dir = Path.Combine(documents, Program.Buildname);
+                    dir = Path.Combine(dir, "UPD");
+
+                    if (!Directory.Exists(dir))
+                    {
+                        Directory.CreateDirectory(dir);
+                    }
+
+                    if (!File.Exists(Path.Combine(dir, "280_" + BLZ + "_" + UserID + ".upd")))
+                    {
+                        using (File.Create(Path.Combine(dir, "280_" + BLZ + "_" + UserID + ".upd")))
+                        { };
+
+                        File.WriteAllText(Path.Combine(dir, "280_" + BLZ + "_" + UserID + ".upd"), upd);
+                    }
+                    else
+                        File.WriteAllText(Path.Combine(dir, "280_" + BLZ + "_" + UserID + ".upd"), upd);
                 }
-
-                if (!File.Exists(Path.Combine(dir, "280_" + BLZ + ".bpd")))
-                {
-                    using (File.Create(Path.Combine(dir, "280_" + BLZ + ".bpd")))
-                    { };
-
-                    File.WriteAllText(Path.Combine(dir, "280_" + BLZ + ".bpd"), bpd);
-                }
-                else
-                    File.WriteAllText(Path.Combine(dir, "280_" + BLZ + ".bpd"), bpd);
-
-				// UPD
-				dir = Path.Combine(documents, Program.Buildname);
-				dir = Path.Combine(dir, "UPD");
-
-				if (!Directory.Exists(dir))
-				{
-					Directory.CreateDirectory(dir);
-				}
-
-                if (!File.Exists(Path.Combine(dir, "280_" + BLZ + "_" + UserID + ".upd")))
-                {
-                    using (File.Create(Path.Combine(dir, "280_" + BLZ + "_" + UserID + ".upd")))
-                    { };
-
-                    File.WriteAllText(Path.Combine(dir, "280_" + BLZ + "_" + UserID + ".upd"), upd);
-                }
-                else
-                    File.WriteAllText(Path.Combine(dir, "280_" + BLZ + "_" + UserID + ".upd"), upd);
 
                 foreach (var item in values)
                 {

--- a/libfintx/Logging/Log.cs
+++ b/libfintx/Logging/Log.cs
@@ -28,32 +28,37 @@ namespace libfintx
 {
     public static class Log
     {
+        public static bool Enabled { get; set; }
+
         public static void Write(string Message)
         {
-            // Directory
-            var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            var dir = Path.Combine(documents, Program.Buildname);
-
-            if (!Directory.Exists(dir))
+            if (Enabled)
             {
-                Directory.CreateDirectory(dir);
+                // Directory
+                var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+                var dir = Path.Combine(documents, Program.Buildname);
+
+                if (!Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                // Logfile
+                dir = Path.Combine(dir, "LOG");
+
+                if (!Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                if (!File.Exists(Path.Combine(dir, "Log.txt")))
+                {
+                    using (File.Create(Path.Combine(dir, "Log.txt")))
+                    { };
+                }
+
+                File.AppendAllText(Path.Combine(dir, "Log.txt"), "[" + DateTime.Now + "]" + " " + Message + Environment.NewLine);
             }
-
-            // Logfile
-            dir = Path.Combine(dir, "LOG");
-
-            if (!Directory.Exists(dir))
-            {
-                Directory.CreateDirectory(dir);
-            }
-
-            if (!File.Exists(Path.Combine(dir, "Log.txt")))
-            {
-                using (File.Create(Path.Combine(dir, "Log.txt")))
-                { };
-            }
-
-            File.AppendAllText(Path.Combine(dir, "Log.txt"), "[" + DateTime.Now + "]" + " " + Message + Environment.NewLine);
         }
     }
 }

--- a/libfintx/MT940/MT940.cs
+++ b/libfintx/MT940/MT940.cs
@@ -408,26 +408,29 @@ namespace libfintx
             if (STA == null || STA.Length == 0)
                 return false;
 
-			var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-			var dir = Path.Combine(documents, Program.Buildname);
+            string documents = "", dir = "";
+            if (Trace.Enabled){
+                documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+                dir = Path.Combine(documents, Program.Buildname);
 
-			dir = Path.Combine(dir, "STA");
+                dir = Path.Combine(dir, "STA");
 
-			if (!Directory.Exists(dir))
-			{
-				Directory.CreateDirectory(dir);
-			}
+                if (!Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
 
-			// STA
-			if (!File.Exists(Path.Combine(dir, Account + ".STA")))
-			{
-				using (File.Create(Path.Combine(dir, Account + ".STA")))
-				{ };
+                // STA
+                if (!File.Exists(Path.Combine(dir, Account + ".STA")))
+                {
+                    using (File.Create(Path.Combine(dir, Account + ".STA")))
+                    { };
 
-				File.AppendAllText(Path.Combine(dir, Account + ".STA"), STA);
-			}
-			else
-				File.AppendAllText(Path.Combine(dir, Account + ".STA"), STA);
+                    File.AppendAllText(Path.Combine(dir, Account + ".STA"), STA);
+                }
+                else
+                    File.AppendAllText(Path.Combine(dir, Account + ".STA"), STA);
+            }
 
             while (STA.Length > 0)
             {
@@ -464,58 +467,62 @@ namespace libfintx
                 Data(swiftTag, swiftData);
             }
 
-            foreach (SWIFTStatement statement in SWIFTStatements)
+
+            if (Trace.Enabled)
             {
-                var ID = statement.id;
-                var Date = statement.date.ToShortDateString();
-                var AccountCode = statement.accountCode;
-                var BanksortCode = statement.bankCode;
-                var Currency = statement.currency;
-                var StartBalance = statement.startBalance.ToString();
-                var EndBalance = statement.endBalance.ToString();
-
-                foreach (SWIFTTransaction transaction in statement.SWIFTTransactions)
+                foreach (SWIFTStatement statement in SWIFTStatements)
                 {
-                    var PartnerName = transaction.partnerName;
-                    var AccountCode_ = transaction.accountCode;
-                    var BankCode = transaction.bankCode;
-                    var Description = transaction.description;
-                    var Text = transaction.text;
-                    var TypeCode = transaction.typecode;
-                    var Amount = transaction.amount.ToString();
+                    var ID = statement.id;
+                    var Date = statement.date.ToShortDateString();
+                    var AccountCode = statement.accountCode;
+                    var BanksortCode = statement.bankCode;
+                    var Currency = statement.currency;
+                    var StartBalance = statement.startBalance.ToString();
+                    var EndBalance = statement.endBalance.ToString();
 
-                    var UMS = "++STARTUMS++" + "ID: " + ID + " ' " +
-                        "Date: " + Date + " ' " +
-                        "AccountCode: " + AccountCode + " ' " +
-                        "BanksortCode: " + BanksortCode + " ' " +
-                        "Currency: " + Currency + " ' " +
-                        "StartBalance: " + StartBalance + " ' " +
-                        "EndBalance: " + EndBalance + " ' " +
-                        "PartnerName: " + PartnerName + " ' " +
-                        "BankCode: " + BankCode + " ' " +
-                        "Description: " + Description + " ' " +
-                        "Text: " + Text + " ' " +
-                        "TypeCode: " + TypeCode + " ' " +
-                        "Amount: " + Amount + " ' " + "++ENDUMS++";
+                    foreach (SWIFTTransaction transaction in statement.SWIFTTransactions)
+                    {
+                        var PartnerName = transaction.partnerName;
+                        var AccountCode_ = transaction.accountCode;
+                        var BankCode = transaction.bankCode;
+                        var Description = transaction.description;
+                        var Text = transaction.text;
+                        var TypeCode = transaction.typecode;
+                        var Amount = transaction.amount.ToString();
 
-					dir = Path.Combine(documents, Program.Buildname);
-					dir = Path.Combine(dir, "MT940");
+                        var UMS = "++STARTUMS++" + "ID: " + ID + " ' " +
+                            "Date: " + Date + " ' " +
+                            "AccountCode: " + AccountCode + " ' " +
+                            "BanksortCode: " + BanksortCode + " ' " +
+                            "Currency: " + Currency + " ' " +
+                            "StartBalance: " + StartBalance + " ' " +
+                            "EndBalance: " + EndBalance + " ' " +
+                            "PartnerName: " + PartnerName + " ' " +
+                            "BankCode: " + BankCode + " ' " +
+                            "Description: " + Description + " ' " +
+                            "Text: " + Text + " ' " +
+                            "TypeCode: " + TypeCode + " ' " +
+                            "Amount: " + Amount + " ' " + "++ENDUMS++";
 
-					if (!Directory.Exists(dir))
-					{
-						Directory.CreateDirectory(dir);
-					}
+                        dir = Path.Combine(documents, Program.Buildname);
+                        dir = Path.Combine(dir, "MT940");
 
-					// MT940
-					if (!File.Exists(Path.Combine(dir, Account + ".MT940")))
-					{
-						using (File.Create(Path.Combine(dir, Account + ".MT940")))
-						{ };
+                        if (!Directory.Exists(dir))
+                        {
+                            Directory.CreateDirectory(dir);
+                        }
 
-						File.AppendAllText(Path.Combine(dir, Account + ".MT940"), UMS);
-					}
-					else
-						File.AppendAllText(Path.Combine(dir, Account + ".MT940"), UMS);
+                        // MT940
+                        if (!File.Exists(Path.Combine(dir, Account + ".MT940")))
+                        {
+                            using (File.Create(Path.Combine(dir, Account + ".MT940")))
+                            { };
+
+                            File.AppendAllText(Path.Combine(dir, Account + ".MT940"), UMS);
+                        }
+                        else
+                            File.AppendAllText(Path.Combine(dir, Account + ".MT940"), UMS);
+                    }
                 }
             }
 

--- a/libfintx/Main.cs
+++ b/libfintx/Main.cs
@@ -1578,5 +1578,13 @@ namespace libfintx
         {
             DEBUG.Enabled = Enabled;
         }
+
+        /// <summary>
+        /// Enable / Disable Logging
+        /// </summary>
+        public static void Logging(bool Enabled)
+        {
+            Log.Enabled = Enabled;
+        }
     }
 }

--- a/libfintx/Message/FinTSMessage.cs
+++ b/libfintx/Message/FinTSMessage.cs
@@ -190,8 +190,7 @@ namespace libfintx
             Log.Write("Connect to FinTS Server");
             Log.Write("Url: " + Url);
 
-            if (Trace.Enabled)
-                Trace.Write(Message);
+            Trace.Write(Message);
 
             try
             {
@@ -224,8 +223,7 @@ namespace libfintx
                     }
                 }
 
-                if (Trace.Enabled)
-                    Trace.Write(FinTSMessage);
+                Trace.Write(FinTSMessage);
 
                 return FinTSMessage;
             }

--- a/libfintx/Traceing/Trace.cs
+++ b/libfintx/Traceing/Trace.cs
@@ -32,30 +32,33 @@ namespace libfintx
 
         public static void Write(string Message)
         {
-            // Directory
-            var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            var dir = Path.Combine(documents, Program.Buildname);
-
-            if (!Directory.Exists(dir))
+            if (Enabled)
             {
-                Directory.CreateDirectory(dir);
+                // Directory
+                var documents = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+                var dir = Path.Combine(documents, Program.Buildname);
+
+                if (!Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                // Tracefile
+                dir = Path.Combine(dir, "TRACE");
+
+                if (!Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                if (!File.Exists(Path.Combine(dir, "Trace.txt")))
+                {
+                    using (File.Create(Path.Combine(dir, "Trace.txt")))
+                    { };
+                }
+
+                File.AppendAllText(Path.Combine(dir, "Trace.txt"), "[" + DateTime.Now + "]" + " " + Message + Environment.NewLine);
             }
-
-            // Tracefile
-            dir = Path.Combine(dir, "TRACE");
-
-            if (!Directory.Exists(dir))
-            {
-                Directory.CreateDirectory(dir);
-            }
-
-            if (!File.Exists(Path.Combine(dir, "Trace.txt")))
-            {
-                using (File.Create(Path.Combine(dir, "Trace.txt")))
-                { };
-            }
-
-            File.AppendAllText(Path.Combine(dir, "Trace.txt"), "[" + DateTime.Now + "]" + " " + Message + Environment.NewLine);
         }
     }
 }

--- a/libfintx/Transactions/INI.cs
+++ b/libfintx/Transactions/INI.cs
@@ -234,8 +234,7 @@ namespace libfintx
 
                     Log.Write(ex.ToString());
 
-                    if (DEBUG.Enabled)
-                        DEBUG.Write("Software error: " + ex.ToString());
+                    DEBUG.Write("Software error: " + ex.ToString());
 
                     throw new Exception("Software error: " + ex.ToString());
                 }


### PR DESCRIPTION
As discussed in this issue https://github.com/mrklintscher/libfintx/issues/15 , I set all File.Write stuff (BPD, UPD, MT940) in dependency to the Trace.Enabled state. So sensitive data will only be written to disk, of the user/programmer chooses to do so.

In consequence of this, I added an Enabled-flag in the Log-class, too. So it is possible to avoid writing to disk at all.