### PR TITLE
Transaction return-values and assembly information

### DIFF
--- a/libfintx/Data/AccountTransaction.cs
+++ b/libfintx/Data/AccountTransaction.cs
@@ -1,0 +1,81 @@
+﻿/*	
+ * 	
+ *  This file is part of libfintx.
+ *  
+ *  Copyright (c) 2016 - 2017 Torsten Klinger
+ * 	E-Mail: torsten.klinger@googlemail.com
+ * 	
+ * 	libfintx is free software; you can redistribute it and/or
+ *	modify it under the terms of the GNU Lesser General Public
+ * 	License as published by the Free Software Foundation; either
+ * 	version 2.1 of the License, or (at your option) any later version.
+ *	
+ * 	libfintx is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * 	Lesser General Public License for more details.
+ *	
+ * 	You should have received a copy of the GNU Lesser General Public
+ * 	License along with libfintx; if not, write to the Free Software
+ * 	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * 	
+ */
+
+
+using System;
+
+namespace libfintx
+{
+    /// <summary>
+    /// Simple account transaction object in libfintx-format
+    /// </summary>
+    public class AccountTransaction
+    {
+        /// <summary>
+        /// Bankaccount of the owner
+        /// </summary>
+        public string OwnerAccount { get; set; }
+
+        /// <summary>
+        /// Bankcode of the owner's bankaccount
+        /// </summary>
+        public string OwnerBankcode{ get; set; }
+
+        /// <summary>
+        /// IBAN of the transaction partner
+        /// </summary>
+        public string PartnerIBAN { get; set; }
+
+        /// <summary>        
+        /// Name of the transaction partner
+        /// </summary>
+        public string PartnerName { get; set; }
+
+
+        /// <summary>
+        /// BIC of the transaction partner
+        /// </summary>
+        public string PartnerBIC { get; set; }
+
+        /// <summary>
+        /// Text/description of the transaction
+        /// </summary>
+        public string RemittanceText { get; set; }
+
+
+        /// <summary>
+        /// Type of the transaction (e.g. FOLGELASTSCHRIFT, AUSZAHLUNG, etc.)
+        /// </summary>
+        public string TransactionType { get; set; }
+
+        /// <summary>
+        /// Date of transaction request
+        /// </summary>
+        public DateTime TransactionDate { get; set; }
+
+        /// <summary>
+        /// Date of booking (valuta-date)
+        /// </summary>
+        public DateTime ValueDate { get; set; }
+    }
+}

--- a/libfintx/MT940/MT940.cs
+++ b/libfintx/MT940/MT940.cs
@@ -395,9 +395,9 @@ namespace libfintx
             return line;
         }
 
-        public static bool Serialize(string STA, string Account)
+        public static List<SWIFTStatement> Serialize(string STA, string Account)
         {
-            Int32 LineCounter = 0;
+            int LineCounter = 0;
 
             string swiftTag = "";
             string swiftData = "";
@@ -406,7 +406,7 @@ namespace libfintx
             SWIFTStatement = null;
 
             if (STA == null || STA.Length == 0)
-                return false;
+                return SWIFTStatements;
 
             string documents = "", dir = "";
             if (Trace.Enabled){
@@ -526,7 +526,7 @@ namespace libfintx
                 }
             }
 
-            return true;
+            return SWIFTStatements;
         }
     }
 }

--- a/libfintx/Main.cs
+++ b/libfintx/Main.cs
@@ -1489,7 +1489,7 @@ namespace libfintx
         }
 
         /// <summary>
-        /// Set assembly informations
+        /// Set assembly information
         /// </summary>
         /// <param name="Buildname"></param>
         /// <param name="Version"></param>
@@ -1501,6 +1501,21 @@ namespace libfintx
             Log.Write(Buildname);
             Log.Write(Version);
         }
+
+
+        /// <summary>
+        /// Set assembly information automatically
+        /// </summary>
+        public static void Assembly()
+        {
+            var assemInfo = System.Reflection.Assembly.GetExecutingAssembly().GetName();
+            Program.Buildname = assemInfo.Name;
+            Program.Version = $"{assemInfo.Version.Major}.{assemInfo.Version.Minor}";
+
+            Log.Write(Program.Buildname);
+            Log.Write(Program.Version);
+        }
+
 
         /// <summary>
         /// Get assembly buildname

--- a/libfintx/Properties/AssemblyInfo.cs
+++ b/libfintx/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Torsten Klinger")]
 [assembly: AssemblyProduct("libfintx")]
-[assembly: AssemblyCopyright("Copyright © 2016 - 2017 Torsten Klinger")]
+[assembly: AssemblyCopyright("Copyright © 2016 - 2018 Torsten Klinger")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/libfintx/libfintx.csproj
+++ b/libfintx/libfintx.csproj
@@ -78,6 +78,7 @@
     <Compile Include="TAN\TAN.cs" />
     <Compile Include="TAN\TAN4.cs" />
     <Compile Include="Traceing\Trace.cs" />
+    <Compile Include="Data\AccountTransaction.cs" />
     <Compile Include="Transactions\HKCCM.cs" />
     <Compile Include="Transactions\HKCCS.cs" />
     <Compile Include="Transactions\HKCCST.cs" />


### PR DESCRIPTION
This PR contains the following changes:

- It adds "List<SWIFTStatement" as return value for the Transactions-method (See: https://github.com/mrklintscher/libfintx/issues/14)
- It adds TransactionSimple-method, which returns an account's transactions in a more simple/logical way (See: https://github.com/mrklintscher/libfintx/issues/14)
- It updates the AssemblyInfo.cs (set the copyright date from "2016 - 2017" to "2016 - 2018"
- It adds an new overload for the Assembly()-method which has no parameters and retrieves program's name and version via reflection. (This should make the use of this lib easier for new users.)