### PR TITLE
FinTS encoding, MatrixCode and AccountBalance

### DIFF
--- a/libfintx/Data/AccountBalance.cs
+++ b/libfintx/Data/AccountBalance.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace libfintx
+{
+    /// <summary>
+    /// Returns an account's balance including currency and status information
+    /// </summary>
+    public class AccountBalance
+    {
+
+        /// <summary>
+        /// Type of the requested account
+        /// </summary>
+        public AccountInformations AccountType { get; set; }
+        
+        /// <summary>
+        /// Balance as decimal value
+        /// </summary>
+        public decimal Balance { get; set; }
+        
+        /// <summary>
+        /// (optional) Transactions which are noted, but not already booked. Will be null if not delivered out by bank.
+        /// </summary>
+        public decimal? MarkedTransactions { get; set; }
+
+        /// <summary>
+        /// (optional) CreditLine - maximum possible credit. Will be null if not delivered out by bank.
+        /// </summary>
+        public decimal? CreditLine { get; set; }
+
+        /// <summary>
+        /// (optional) Balance available including credit line. Will be null if not delivered out by bank.
+        /// </summary>
+        public decimal? AvailableBalance { get; set; }        
+
+        /// <summary>
+        /// Returns status of balance request
+        /// </summary>
+        public bool Successful { get; set; }
+
+        /// <summary>
+        /// Returns error message if balance request failed (Successful==false) or status message if request was successful
+        /// </summary>
+        public string Message { get; set; }
+    }
+}

--- a/libfintx/Data/AccountInformations.cs
+++ b/libfintx/Data/AccountInformations.cs
@@ -26,7 +26,9 @@ namespace libfintx
     public class AccountInformations
     {
         public string Accountnumber { get; set; }
+        public string Accountbankcode { get; set; }
         public string Accountowner { get; set; }
         public string Accounttype { get; set; }
+        public string Accountcurrency { get; set; }
     }
 }

--- a/libfintx/Helper/Helper.cs
+++ b/libfintx/Helper/Helper.cs
@@ -342,18 +342,77 @@ namespace libfintx
             }
         }
 
-        public static string Parse_Balance(string Message)
+        public static AccountBalance Parse_Balance(string Message)
         {
-            var Balance = Parse_String(Message, "+EUR+", ":EUR:");
+            var hirms = Message.Substring(Message.IndexOf("HIRMS")+5);
+            hirms = hirms.Substring(0, (hirms.Contains("'") ? hirms.IndexOf('\'') : hirms.Length));
+            var hirmsParts = hirms.Split(':');
 
-            if (Balance.Contains("C:"))
-                Balance = Balance.Replace("C:", "");
-            else if (Balance.Contains("D:"))
-                Balance = "-" + Balance.Replace("D:", "");
+            AccountBalance balance = new AccountBalance();
+            balance.Message = hirmsParts[hirmsParts.Length - 1];
+
+            if (Message.Contains("+0020::"))
+            {
+                var hisal = Message.Substring(Message.IndexOf("HISAL")+5);
+                hisal = hisal.Substring(0, (hisal.Contains("'") ? hisal.IndexOf('\'') : hisal.Length));
+                var hisalParts = hisal.Split('+');
+
+                balance.Successful = true;
+
+                var hisalAccountParts = hisalParts[1].Split(':');
+                balance.AccountType = new AccountInformations()
+                {
+                     Accountnumber = hisalAccountParts[0],
+                     Accountbankcode = hisalAccountParts[3],
+                     Accounttype = hisalParts[2],                     
+                     Accountcurrency = hisalParts[3]
+                };
+
+                var hisalBalanceParts = hisalParts[4].Split(':');
+                balance.Balance = Convert.ToDecimal($"{(hisalBalanceParts[0] == "D" ? "-" : "")}{hisalBalanceParts[1]}");
+
+            
+                //from here on optional fields / see page 46 in "FinTS_3.0_Messages_Geschaeftsvorfaelle_2015-08-07_final_version.pdf"
+                if (hisalParts.Length > 5)
+                {
+                    var hisalMarkedBalanceParts = hisalParts[5].Split(':');
+                    balance.MarkedTransactions = Convert.ToDecimal($"{(hisalMarkedBalanceParts[0] == "D" ? "-" : "")}{hisalMarkedBalanceParts[1]}");
+                }
+
+                if (hisalParts.Length > 6)
+                {                    
+                    balance.CreditLine = Convert.ToDecimal(hisalParts[6].Split(':')[0].TrimEnd(','));
+                }
+
+                if (hisalParts.Length > 7)
+                {
+                    balance.AvailableBalance = Convert.ToDecimal(hisalParts[7].Split(':')[0].TrimEnd(','));
+                }
+
+                /* ---------------------------------------------------------------------------------------------------------
+                 * In addition to the above fields, the following fields from HISAL could also be implemented:
+                 * 
+                 * - 9/Bereits verfügter Betrag
+                 * - 10/Überziehung
+                 * - 11/Buchungszeitpunkt
+                 * - 12/Fälligkeit 
+                 * 
+                 * Unfortunately I'm missing test samples. So I drop support unless we get test messages for this fields.
+                 ------------------------------------------------------------------------------------------------------------ */
+            }
             else
-                Balance = string.Empty;
+            {
+                balance.Successful = false;
+                              
+                string msg = string.Empty;
+                for (int i = 1; i < hirmsParts.Length; i++)
+                {                    
+                    msg = msg + "??" + hirmsParts[i].Replace("::", ": ");
+                }
+                Log.Write(msg);                
+            }
 
-            return Balance;
+            return balance;
         }
 
         public static bool Parse_Accounts(string Message, List<AccountInformations> Items)
@@ -434,3 +493,6 @@ namespace libfintx
         }
     }
 }
+ 
+ 
+ 

--- a/libfintx/Helper/Helper.cs
+++ b/libfintx/Helper/Helper.cs
@@ -74,7 +74,7 @@ namespace libfintx
         static public string DecodeFrom64EncodingDefault(string encodedData)
         {
             byte[] encodedDataAsBytes = Convert.FromBase64String(encodedData);
-            string returnValue = Encoding.GetEncoding("iso8859-1").GetString(encodedDataAsBytes);
+            string returnValue = Encoding.GetEncoding("ISO-8859-1").GetString(encodedDataAsBytes);
 
             return returnValue;
         }

--- a/libfintx/Main.cs
+++ b/libfintx/Main.cs
@@ -323,7 +323,7 @@ namespace libfintx
 
                         }
 
-                        MatrixCode.setCode(Encoding.Default.GetBytes(PhotoCode), pictureBox);
+                        var mCode = new MatrixCode(PhotoCode);
                     }
 
                     return "OK";
@@ -488,7 +488,7 @@ namespace libfintx
 
                         }
 
-                        MatrixCode.setCode(Encoding.Default.GetBytes(PhotoCode), pictureBox);
+                        var mCode = new MatrixCode(PhotoCode);
                     }
 
                     return "OK";
@@ -650,7 +650,7 @@ namespace libfintx
 
                         }
 
-                        MatrixCode.setCode(Encoding.Default.GetBytes(PhotoCode), pictureBox);
+                        var mCode = new MatrixCode(PhotoCode);
                     }
 
                     return "OK";
@@ -813,7 +813,7 @@ namespace libfintx
 
                         }
 
-                        MatrixCode.setCode(Encoding.Default.GetBytes(PhotoCode), pictureBox);
+                        var mCode = new MatrixCode(PhotoCode);
                     }
 
                     return "OK";
@@ -977,7 +977,7 @@ namespace libfintx
 
                         }
 
-                        MatrixCode.setCode(Encoding.Default.GetBytes(PhotoCode), pictureBox);
+                        var mCode = new MatrixCode(PhotoCode);
                     }
 
                     return "OK";
@@ -1143,7 +1143,7 @@ namespace libfintx
 
                         }
 
-                        MatrixCode.setCode(Encoding.Default.GetBytes(PhotoCode), pictureBox);
+                        var mCode = new MatrixCode(PhotoCode);
                     }
 
                     return "OK";
@@ -1304,7 +1304,7 @@ namespace libfintx
 
                         }
 
-                        MatrixCode.setCode(Encoding.Default.GetBytes(PhotoCode), pictureBox);
+                        var mCode = new MatrixCode(PhotoCode);
                     }
 
                     return "OK";
@@ -1463,7 +1463,7 @@ namespace libfintx
 
                         }
 
-                        MatrixCode.setCode(Encoding.Default.GetBytes(PhotoCode), pictureBox);
+                        var mCode = new MatrixCode(PhotoCode);
                     }
 
                     return "OK";
@@ -1632,7 +1632,7 @@ namespace libfintx
 
                         }
 
-                        MatrixCode.setCode(Encoding.Default.GetBytes(PhotoCode), pictureBox);
+                        var mCode = new MatrixCode(PhotoCode);
                     }
 
                     return "OK";

--- a/libfintx/Main.cs
+++ b/libfintx/Main.cs
@@ -69,43 +69,21 @@ namespace libfintx
         /// <param name="PIN"></param>
         /// <param name="Anonymous"></param>
         /// <returns>
-        /// Balance
+        /// Structured information about balance, creditline and used currency
         /// </returns>
-        public static string Balance(string Account, int BLZ, string IBAN, string BIC, string URL, int HBCIVersion,
+        public static AccountBalance Balance(string Account, int BLZ, string IBAN, string BIC, string URL, int HBCIVersion,
             string UserID, string PIN, bool Anonymous)
-        {
+        {            
             if (Transaction.INI(BLZ, URL, HBCIVersion, UserID, PIN, Anonymous) == true)
             {
                 // Success
                 var BankCode = Transaction.HKSAL(Account, BLZ, IBAN, BIC, URL, HBCIVersion, UserID, PIN);
-
-                if (BankCode.Contains("+0020::"))
-                {
-                    // Success
-                    return "Kontostand: " + Helper.Parse_Balance(BankCode);
-                }
-                else
-                {
-                    // Error 
-                    var BankCode_ = "HIRMS" + Helper.Parse_String(BankCode, "'HIRMS", "'");
-
-                    String[] values = BankCode_.Split('+');
-
-                    string msg = string.Empty;
-
-                    foreach (var item in values)
-                    {
-                        if (!item.StartsWith("HIRMS"))
-                            msg = msg + "??" + item.Replace("::", ": ");
-                    }
-
-                    Log.Write(msg);
-
-                    return msg;
-                }
+                return Helper.Parse_Balance(BankCode);
             }
-            else
-                return "Error";
+            else {
+                Log.Write("Error in initialization.");
+                throw new Exception("Error in initialization.");
+            }
         }
 
         /// <summary>

--- a/libfintx/Message/FinTSMessage.cs
+++ b/libfintx/Message/FinTSMessage.cs
@@ -218,7 +218,7 @@ namespace libfintx
                     {
                         using (StreamReader streamReader = new StreamReader(resStream, Encoding.UTF8))
                         {
-                            FinTSMessage = Helper.DecodeFrom64(streamReader.ReadToEnd());
+                            FinTSMessage = Helper.DecodeFrom64EncodingDefault(streamReader.ReadToEnd());                            
                         }
                     }
                 }

--- a/libfintx/libfintx.csproj
+++ b/libfintx/libfintx.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Console\TransactionConsole.cs" />
+    <Compile Include="Data\AccountBalance.cs" />
     <Compile Include="Data\AccountInformations.cs" />
     <Compile Include="Data\pain00100203_ct_data.cs" />
     <Compile Include="Data\pain00800202_cc_data.cs" />


### PR DESCRIPTION
This PR fixes and/or enhances the following points:
- Changes FinTS response encoding to ISO-8859-1 to work correctly with umlauts. Done in this commit https://github.com/mrklintscher/libfintx/commit/4cb2b5cf25d967162148f1a02f74edaf970486a0 which solves this issue https://github.com/mrklintscher/libfintx/issues/22
- Fixes/finishes the MatrixCode class. Images are created correctly and GUI components were removed. This is done by https://github.com/mrklintscher/libfintx/commit/13052d58d49615f35979ea0b5e11a748b3acc3aa and regards to https://github.com/mrklintscher/libfintx/issues/19
- Reworks the AccountBalance method. Before the Balance returned a string with value and currency, which isn't optimal to use. (E.g. someone want's to calculate with the balance. In that case he had to parse the return value and convert it.) Now the AccountBalance method returns more and better structured information. This is done in https://github.com/mrklintscher/libfintx/commit/5cd489cb6154ba71b4ae62a8212ccd9ef634160e

Hope you like the changes...