### PR TITLE
Make sub fields in swift transaction description explicit

### DIFF
--- a/libfintx/MT940/MT940.cs
+++ b/libfintx/MT940/MT940.cs
@@ -437,7 +437,6 @@ namespace libfintx
                 Content = String.Empty;
             }
 
-            line = line.Trim();
             line = line.Replace("™", "Ö");
             line = line.Replace("š", "Ü");
             line = line.Replace("Ž", "Ä");

--- a/libfintx/SWIFT/SWIFTTransaction.cs
+++ b/libfintx/SWIFT/SWIFTTransaction.cs
@@ -44,5 +44,34 @@ namespace libfintx
         public string accountCode;
 
         public string partnerName;
-    }
+
+		//Ende-zu-Ende Referenz
+		public string EREF;
+		//Kundenreferenz
+		public string KREF;
+		//Mandatsreferenz
+		public string MREF;
+		//Bankreferenz
+		public string BREF;
+		//Retourenreferenz
+		public string RREF;
+		//Creditor-ID
+		public string CRED;
+		//Debitor-ID
+		public string DEBT;
+		//Zinskompensationsbetrag
+		public string COAM;
+		//Ursprünglicher Umsatzbetrag
+		public string OAMT;
+		//Verwendungszweck
+		public string SVWZ;
+		//Abweichender Auftraggeber
+		public string ABWA;
+		//Abweichender Empfänger
+		public string ABWE;
+		//IBAN des Auftraggebers
+		public string IBAN;
+		//BIC des Auftraggebers
+		public string BIC;
+	}
 }


### PR DESCRIPTION
Added properties for swift transactions to make subfields explicit.