### PR TITLE
add handling of @@ instead of newline chars

### DIFF
--- a/libfintx/MT940/MT940.cs
+++ b/libfintx/MT940/MT940.cs
@@ -410,7 +410,7 @@ namespace libfintx
 
             for (counter = 0; counter < Content.Length; counter++)
             {
-                if ((Content[counter] == (char)10) || (Content[counter] == (char)13))
+                if ((Content[counter] == (char)10) || (Content[counter] == (char)13) || (Content[counter] == '@'))
                 {
                     break;
                 }
@@ -424,6 +424,11 @@ namespace libfintx
             }
 
             if ((counter < Content.Length) && (Content[counter] == (char)10))
+            {
+                counter++;
+            }
+		
+	    while ((counter < Content.Length) && (Content[counter] == '@'))
             {
                 counter++;
             }


### PR DESCRIPTION
Volksbank Meerbusch (BLZ 37069164 BIC GENODED1MBU)