### PR TITLE
Fixed AppVeyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 version: '1.0.{build}'
-image: Visual Studio 2017
+image: Visual Studio 2019
 branches:
   only:
   - master


### PR DESCRIPTION
Currently, builds are failing due to

    dotnet restore ./src/libfintx.Tests/libfintx.Tests.csproj --verbosity m
    C:\Program Files\dotnet\sdk\2.2.402\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(137,5): error NETSDK1045: The current .NET SDK does not support targeting .NET Core 3.0.  Either target .NET Core 2.2 or lower, or use a version of the .NET SDK that supports .NET Core 3.0. [C:\projects\libfintx\src\libfintx.Tests\libfintx.Tests.csproj]
    Command exited with code 1

This PR is supposed to fix that issue