### PR TITLE
SecurityProtocol and Redesign/Simplify

### DIFF
--- a/src/libfintx/Data/ConnectionDetails.cs
+++ b/src/libfintx/Data/ConnectionDetails.cs
@@ -1,4 +1,6 @@
-﻿namespace libfintx.Data
+﻿using System.Net; // Perhaps using int -> SecurityProtocolType conversion better than binding a lib to this class.
+
+namespace libfintx.Data
 {
     public class ConnectionDetails
     {
@@ -62,8 +64,12 @@
         /// </summary>
         public string CustomerSystemId { get; set; }
 
+        // Security
+        public SecurityProtocolType SecurityProtocol { get; set; }
+
         public ConnectionDetails()
         {
+            SecurityProtocol = SecurityProtocolType.Tls12; 
             HbciVersion = 300;
         }
     }

--- a/src/libfintx/Segments/HKCAZ.cs
+++ b/src/libfintx/Segments/HKCAZ.cs
@@ -108,8 +108,8 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            string response = await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            string response = await FinTSMessage.Send(client, message);
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(response, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKCCM.cs
+++ b/src/libfintx/Segments/HKCCM.cs
@@ -52,8 +52,8 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            var response = await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            var response = await FinTSMessage.Send(client, message);
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(response, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKCCS.cs
+++ b/src/libfintx/Segments/HKCCS.cs
@@ -65,8 +65,8 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            var message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            var response = await FinTSMessage.Send(connectionDetails.Url, message);
+            var message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            var response = await FinTSMessage.Send(client, message);
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(response, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKCDB.cs
+++ b/src/libfintx/Segments/HKCDB.cs
@@ -23,8 +23,8 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            string response = await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            string response = await FinTSMessage.Send(client, message);
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(response, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKCDE.cs
+++ b/src/libfintx/Segments/HKCDE.cs
@@ -55,8 +55,8 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            var response = await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            var response = await FinTSMessage.Send(client, message);
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(response, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKCDL.cs
+++ b/src/libfintx/Segments/HKCDL.cs
@@ -32,8 +32,8 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            var TAN = await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            var TAN = await FinTSMessage.Send(client, message);
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(TAN, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKCDN.cs
+++ b/src/libfintx/Segments/HKCDN.cs
@@ -33,8 +33,8 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            var TAN = await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            var TAN = await FinTSMessage.Send(client, message);
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(TAN, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKCME.cs
+++ b/src/libfintx/Segments/HKCME.cs
@@ -53,8 +53,8 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            var response = await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            var response = await FinTSMessage.Send(client, message);
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(response, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKCSB.cs
+++ b/src/libfintx/Segments/HKCSB.cs
@@ -46,8 +46,8 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            string response = await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            string response = await FinTSMessage.Send(client, message);
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(response, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKCSE.cs
+++ b/src/libfintx/Segments/HKCSE.cs
@@ -65,8 +65,8 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            var message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            var response = await FinTSMessage.Send(connectionDetails.Url, message);
+            var message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            var response = await FinTSMessage.Send(client, message);
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(response, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKCUM.cs
+++ b/src/libfintx/Segments/HKCUM.cs
@@ -50,7 +50,7 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            var TAN = await FinTSMessage.Send(connectionDetails.Url, FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM));
+            var TAN = await FinTSMessage.Send(client, FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS));
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(TAN, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKDME.cs
+++ b/src/libfintx/Segments/HKDME.cs
@@ -53,7 +53,7 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            var TAN = await FinTSMessage.Send(connectionDetails.Url, FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM));
+            var TAN = await FinTSMessage.Send(client, FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS));
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(TAN, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKDSE.cs
+++ b/src/libfintx/Segments/HKDSE.cs
@@ -50,7 +50,7 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            var TAN = await FinTSMessage.Send(connectionDetails.Url, FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM));
+            var TAN = await FinTSMessage.Send(client, FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS));
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(TAN, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKEND.cs
+++ b/src/libfintx/Segments/HKEND.cs
@@ -44,8 +44,8 @@ namespace libfintx
 
             client.SEGNUM = SEGNUM.SETInt(3);
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            return await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            return await FinTSMessage.Send(client, message);
         }
     }
 }

--- a/src/libfintx/Segments/HKKAZ.cs
+++ b/src/libfintx/Segments/HKKAZ.cs
@@ -81,8 +81,8 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            string response = await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            string response = await FinTSMessage.Send(client, message);
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(response, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKPPD.cs
+++ b/src/libfintx/Segments/HKPPD.cs
@@ -46,8 +46,8 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            var TAN = await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            var TAN = await FinTSMessage.Send(client, message);
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(TAN, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKSAL.cs
+++ b/src/libfintx/Segments/HKSAL.cs
@@ -51,8 +51,8 @@ namespace libfintx
                 segments = HKTAN.Init_HKTAN(client, segments);
             }
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            string response = await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            string response = await FinTSMessage.Send(client, message);
 
             client.HITAN = Helper.Parse_String(Helper.Parse_String(response, "HITAN", "'").Replace("?+", "??"), "++", "+").Replace("??", "?+");
 

--- a/src/libfintx/Segments/HKSPA.cs
+++ b/src/libfintx/Segments/HKSPA.cs
@@ -44,7 +44,7 @@ namespace libfintx
 
             client.SEGNUM = SEGNUM.SETInt(3);
 
-            return await FinTSMessage.Send(connectionDetails.Url, FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM));
+            return await FinTSMessage.Send(client, FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS));
         }
     }
 }

--- a/src/libfintx/Segments/HKSYN.cs
+++ b/src/libfintx/Segments/HKSYN.cs
@@ -66,8 +66,8 @@ namespace libfintx
 
             client.SEGNUM = SEGNUM.SETInt(5);
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, "1", "0", connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, "0", segments, null, client.SEGNUM);
-            string response = await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.CreateSync(client, segments);
+            string response = await FinTSMessage.Send(client, message);
 
             Helper.Parse_Segment(client, response);
 

--- a/src/libfintx/Segments/HKTAB.cs
+++ b/src/libfintx/Segments/HKTAB.cs
@@ -42,8 +42,8 @@ namespace libfintx
 
             client.SEGNUM = SEGNUM.SETInt(3);
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-            return await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS);
+            return await FinTSMessage.Send(client, message);
         }
     }
 }

--- a/src/libfintx/Tan/Tan.cs
+++ b/src/libfintx/Tan/Tan.cs
@@ -82,8 +82,8 @@ namespace libfintx
 
             client.SEGNUM = SEGNUM.SETInt(3);
 
-            string message = FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS + ":" + TAN, client.SEGNUM);
-            string response = await FinTSMessage.Send(connectionDetails.Url, message);
+            string message = FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS + ":" + TAN);
+            string response = await FinTSMessage.Send(client, message);
 
             Helper.Parse_Message(client, response);
 

--- a/src/libfintx/Tan/Tan4.cs
+++ b/src/libfintx/Tan/Tan4.cs
@@ -44,15 +44,15 @@ namespace libfintx
             if (HITANS == 3)
                 segments = "HKTAN:" + SEGNUM.SETVal(3) + ":" + client.HITANS.Substring(0, 1) + "+4+++++++" + MediumName + "'";
             // Version 4
-            if (HITANS == 4)
+            else if (HITANS == 4)
                 segments = "HKTAN:" + SEGNUM.SETVal(3) + ":" + client.HITANS.Substring(0, 1) + "+4++++++++" + MediumName + "'";
             // Version 5
-            if (HITANS == 5)
+            else if (HITANS == 5)
                 segments = "HKTAN:" + SEGNUM.SETVal(3) + ":" + client.HITANS.Substring(0, 1) + "+4++++++++++" + MediumName + "'";
 
             client.SEGNUM = SEGNUM.SETInt(3);
 
-            return await FinTSMessage.Send(connectionDetails.Url, FinTSMessage.Create(connectionDetails.HbciVersion, client.HNHBS, client.HNHBK, connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS + ":" + TAN, client.SEGNUM));
+            return await FinTSMessage.Send(client, FinTSMessage.Create(client, client.HNHBS, client.HNHBK, segments, client.HIRMS + ":" + TAN));
         }
     }
 }

--- a/src/libfintx/Transactions/INI.cs
+++ b/src/libfintx/Transactions/INI.cs
@@ -83,8 +83,8 @@ namespace libfintx
                         throw new Exception("HBCI version not supported");
                     }
 
-                    var message = FinTSMessage.Create(connectionDetails.HbciVersion, "1", "0", connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-                    var response = await FinTSMessage.Send(connectionDetails.Url, message);
+                    var message = FinTSMessage.Create(client, "1", "0", segments, client.HIRMS);
+                    var response = await FinTSMessage.Send(client, message);
 
                     Helper.Parse_Segment(client, response);
 
@@ -136,7 +136,7 @@ namespace libfintx
                     client.SEGNUM = SEGNUM.SETInt(4);
 
                     string message = FinTsMessageAnonymous.Create(connectionDetails.HbciVersion, "1", "0", connectionDetails.Blz, connectionDetails.UserId, connectionDetails.Pin, "0", segments, null, client.SEGNUM);
-                    string response = await FinTSMessage.Send(connectionDetails.Url, message);
+                    string response = await FinTSMessage.Send(client, message);
 
                     var messages = Helper.Parse_Segment(client, response);
                     var result = new HBCIDialogResult(messages, response);
@@ -170,8 +170,8 @@ namespace libfintx
 
                     client.SEGNUM = SEGNUM.SETInt(5);
 
-                    message = FinTSMessage.Create(connectionDetails.HbciVersion, "1", "0", connectionDetails.BlzPrimary, connectionDetails.UserId, connectionDetails.Pin, client.SystemId, segments, client.HIRMS, client.SEGNUM);
-                    response = await FinTSMessage.Send(connectionDetails.Url, message);
+                    message = FinTSMessage.Create(client, "1", "0", segments, client.HIRMS);
+                    response = await FinTSMessage.Send(client, message);
 
                     Helper.Parse_Segment(client, response);
 


### PR DESCRIPTION
(iwen65)First redesign to make things easier and more readable. All important params were values that had been stored as properties of the FinTsClient.

If this is connected as close as this it is better to pass the client as ref parameter, that makes the hole method much more flexible and extendable without breaking changes.

ConnectionDetails is part of the client too. We can handle the new added ServiceProtocolType inside the common connectioninfo without breaking changes too. Mostly it will be TLS12 but who knows.