### PR TITLE
Migrate to .NET Standard nugets

### DIFF
--- a/src/libfintx.Sample.Ui/App.config
+++ b/src/libfintx.Sample.Ui/App.config
@@ -19,7 +19,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.4.1" newVersion="4.0.4.1" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/libfintx.Sample.Ui/libfintx.Sample.Ui.csproj
+++ b/src/libfintx.Sample.Ui/libfintx.Sample.Ui.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Net.Compilers.Toolset.3.1.0\build\Microsoft.Net.Compilers.Toolset.props" Condition="Exists('..packages\Microsoft.Net.Compilers.Toolset.3.1.0\build\Microsoft.Net.Compilers.Toolset.props')" />
-  <Import Project="..\packages\Microsoft.Net.Compilers.3.1.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.3.1.0\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.Toolset.3.8.0\build\Microsoft.Net.Compilers.Toolset.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.Toolset.3.8.0\build\Microsoft.Net.Compilers.Toolset.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.3.8.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.3.8.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="..\packages\Microsoft.Net.Compilers.Toolset.3.1.0\build\Microsoft.Net.Compilers.Toolset.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.Toolset.3.1.0\build\Microsoft.Net.Compilers.Toolset.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -41,22 +41,22 @@
       <HintPath>..\packages\SixLabors.Core.1.0.0-beta0008\lib\netstandard2.0\SixLabors.Core.dll</HintPath>
     </Reference>
     <Reference Include="SixLabors.ImageSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d998eea7b14cab13, processorArchitecture=MSIL">
-      <HintPath>..\packages\SixLabors.ImageSharp.1.0.0-rc0003\lib\netstandard2.0\SixLabors.ImageSharp.dll</HintPath>
+      <HintPath>..\packages\SixLabors.ImageSharp.1.0.2\lib\netstandard2.0\SixLabors.ImageSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -115,4 +115,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.3.8.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.3.8.0\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.Toolset.3.8.0\build\Microsoft.Net.Compilers.Toolset.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.Toolset.3.8.0\build\Microsoft.Net.Compilers.Toolset.props'))" />
+  </Target>
 </Project>

--- a/src/libfintx.Sample.Ui/libfintx.Sample.Ui.csproj
+++ b/src/libfintx.Sample.Ui/libfintx.Sample.Ui.csproj
@@ -37,9 +37,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="SixLabors.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SixLabors.Core.1.0.0-beta0008\lib\netstandard2.0\SixLabors.Core.dll</HintPath>
-    </Reference>
     <Reference Include="SixLabors.ImageSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=d998eea7b14cab13, processorArchitecture=MSIL">
       <HintPath>..\packages\SixLabors.ImageSharp.1.0.2\lib\netstandard2.0\SixLabors.ImageSharp.dll</HintPath>
     </Reference>

--- a/src/libfintx.Sample.Ui/packages.config
+++ b/src/libfintx.Sample.Ui/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="Microsoft.Net.Compilers" version="3.8.0" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.Net.Compilers.Toolset" version="3.8.0" targetFramework="net461" developmentDependency="true" />
-  <package id="SixLabors.Core" version="1.0.0-beta0008" targetFramework="net461" />
   <package id="SixLabors.ImageSharp" version="1.0.2" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
   <package id="System.Memory" version="4.5.4" targetFramework="net461" />

--- a/src/libfintx.Sample.Ui/packages.config
+++ b/src/libfintx.Sample.Ui/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Net.Compilers" version="3.1.0" targetFramework="net461" developmentDependency="true" />
-  <package id="Microsoft.Net.Compilers.Toolset" version="3.1.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers" version="3.8.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.Net.Compilers.Toolset" version="3.8.0" targetFramework="net461" developmentDependency="true" />
   <package id="SixLabors.Core" version="1.0.0-beta0008" targetFramework="net461" />
-  <package id="SixLabors.ImageSharp" version="1.0.0-rc0003" targetFramework="net461" />
-  <package id="System.Buffers" version="4.5.0" targetFramework="net461" />
-  <package id="System.Memory" version="4.5.3" targetFramework="net461" />
+  <package id="SixLabors.ImageSharp" version="1.0.2" targetFramework="net461" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net461" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net461" />
 </packages>

--- a/src/libfintx.Sample/libfintx.Sample.csproj
+++ b/src/libfintx.Sample/libfintx.Sample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.7.82" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libfintx.Tests/libfintx.Tests.csproj
+++ b/src/libfintx.Tests/libfintx.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/libfintx/Commands/DeserializeResponse.cs
+++ b/src/libfintx/Commands/DeserializeResponse.cs
@@ -7,15 +7,12 @@
  */
 
 using libfintx.Handler;
-using StatePrinting;
-using StatePrinting.OutputFormatters;
+using Newtonsoft.Json;
 
 namespace libfintx.Commands
 {
     internal class DeserializeResponse
-    {
-        private static readonly Stateprinter _printer;
-        
+    {       
         public int NumSegments { get; set; }
         public int SegmentNumber { get; set; }
         public bool LastSegment { get; set; }
@@ -38,13 +35,10 @@ namespace libfintx.Commands
         
         static DeserializeResponse()
         {
-            _printer = new Stateprinter();
-            _printer.Configuration.SetNewlineDefinition("");
-            _printer.Configuration.SetIndentIncrement(" ");
-            _printer.Configuration.SetOutputFormatter(new JsonStyle(_printer.Configuration));
+
         }
 
-        public override string ToString() => _printer.PrintObject(this);
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
     }
     
     

--- a/src/libfintx/Config/BankParams.cs
+++ b/src/libfintx/Config/BankParams.cs
@@ -6,14 +6,13 @@
  * file 'LICENSE.txt', which is part of this source code package.
  */
 
-using StatePrinting;
-using StatePrinting.OutputFormatters;
+using Newtonsoft.Json;
 
 namespace libfintx.Config
 {
     public class BankParams
     {
-        private static readonly Stateprinter _printer;
+        
         
         public AuthKeyPair AuthKeys { get; set; }
         public CryptKeyPair CryptKeys { get; set; }
@@ -21,12 +20,9 @@ namespace libfintx.Config
 
         static BankParams()
         {
-            _printer = new Stateprinter();
-            _printer.Configuration.SetNewlineDefinition("");
-            _printer.Configuration.SetIndentIncrement(" ");
-            _printer.Configuration.SetOutputFormatter(new JsonStyle(_printer.Configuration));
+
         }
 
-        public override string ToString() => _printer.PrintObject(this);
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
     }
 }

--- a/src/libfintx/Config/EBICSConfig.cs
+++ b/src/libfintx/Config/EBICSConfig.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * NetEbics -- .NET Core EBICS Client Library
  * (c) Copyright 2018 Bjoern Kuensting
  *
@@ -6,14 +6,13 @@
  * file 'LICENSE.txt', which is part of this source code package.
  */
 
-using StatePrinting;
-using StatePrinting.OutputFormatters;
+using Newtonsoft.Json;
 
 namespace libfintx.Config
 {
     public class EbicsConfig
     {
-        private static readonly Stateprinter _printer;
+        
         
         public string Address { get; set; }
         public bool TLS { get; set; }
@@ -26,12 +25,9 @@ namespace libfintx.Config
 
         static EbicsConfig()
         {
-            _printer = new Stateprinter();
-            _printer.Configuration.SetNewlineDefinition("");
-            _printer.Configuration.SetIndentIncrement(" ");
-            _printer.Configuration.SetOutputFormatter(new JsonStyle(_printer.Configuration));
+
         }
 
-        public override string ToString() => _printer.PrintObject(this);
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
     }
 }

--- a/src/libfintx/Config/KeyPair.cs
+++ b/src/libfintx/Config/KeyPair.cs
@@ -10,17 +10,13 @@ using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using StatePrinting;
-using StatePrinting.Configurations;
-using StatePrinting.FieldHarvesters;
-using StatePrinting.OutputFormatters;
-using StatePrinting.ValueConverters;
+using Newtonsoft.Json;
 
 namespace libfintx.Config
 {
     public abstract class KeyPair<T> : IDisposable
     {
-        private static readonly Stateprinter _printer;
+        
         
         protected RSA _publicKey;
         protected RSA _privateKey;
@@ -100,20 +96,9 @@ namespace libfintx.Config
 
         static KeyPair()
         {
-            var cfg = new Configuration();
-
-            cfg.SetIndentIncrement(" ");            
-            cfg.OutputFormatter = new JsonStyle(cfg);
             
-            cfg.Add(new StandardTypesConverter(cfg));
-            cfg.Add(new StringConverter());
-            cfg.Add(new DateTimeConverter(cfg));
-            cfg.Add(new EnumConverter());
-            cfg.Add(new PublicFieldsAndPropertiesHarvester());
-
-            _printer = new Stateprinter(cfg);            
         }
 
-        public override string ToString() => _printer.PrintObject(this);
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
     }
 }

--- a/src/libfintx/Config/NamespaceConfig.cs
+++ b/src/libfintx/Config/NamespaceConfig.cs
@@ -6,14 +6,13 @@
  * file 'LICENSE.txt', which is part of this source code package.
  */
 
-using StatePrinting;
-using StatePrinting.OutputFormatters;
+using Newtonsoft.Json;
 
 namespace libfintx.Config
 {
     internal class NamespaceConfig
     {
-        private static readonly Stateprinter _printer;
+        
         
         internal string Ebics { get; set; }
 
@@ -30,12 +29,9 @@ namespace libfintx.Config
         
         static NamespaceConfig()
         {
-            _printer = new Stateprinter();
-            _printer.Configuration.SetNewlineDefinition("");
-            _printer.Configuration.SetIndentIncrement(" ");
-            _printer.Configuration.SetOutputFormatter(new JsonStyle(_printer.Configuration));
+
         }
 
-        public override string ToString() => _printer.PrintObject(this);
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
     }
 }

--- a/src/libfintx/Config/UserParams.cs
+++ b/src/libfintx/Config/UserParams.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * NetEbics -- .NET Core EBICS Client Library
  * (c) Copyright 2018 Bjoern Kuensting
  *
@@ -6,14 +6,13 @@
  * file 'LICENSE.txt', which is part of this source code package.
  */
 
-using StatePrinting;
-using StatePrinting.OutputFormatters;
+using Newtonsoft.Json;
 
 namespace libfintx.Config
 {
     public class UserParams
     {
-        private static readonly Stateprinter _printer;
+        
         
         public string HostId { get; set; }
         public string UserId { get; set; }
@@ -26,12 +25,9 @@ namespace libfintx.Config
 
         static UserParams()
         {
-            _printer = new Stateprinter();
-            _printer.Configuration.SetNewlineDefinition("");
-            _printer.Configuration.SetIndentIncrement(" ");
-            _printer.Configuration.SetOutputFormatter(new JsonStyle(_printer.Configuration));
+
         }
 
-        public override string ToString() => _printer.PrintObject(this);
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
     }
 }

--- a/src/libfintx/Parameters/Params.cs
+++ b/src/libfintx/Parameters/Params.cs
@@ -6,25 +6,21 @@
  * file 'LICENSE.txt', which is part of this source code package.
  */
 
-using StatePrinting;
-using StatePrinting.OutputFormatters;
+using Newtonsoft.Json;
 
 namespace libfintx.Parameters
 {
     public abstract class Params
     {
-        private static readonly Stateprinter _printer;
+        
 
         public string SecurityMedium { get; set; } = "0000";
 
         static Params()
         {
-            _printer = new Stateprinter();
-            _printer.Configuration.SetNewlineDefinition("");
-            _printer.Configuration.SetIndentIncrement(" ");
-            _printer.Configuration.SetOutputFormatter(new JsonStyle(_printer.Configuration));
+
         }
 
-        public override string ToString() => _printer.PrintObject(this);
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
     }
 }

--- a/src/libfintx/Responses/Response.cs
+++ b/src/libfintx/Responses/Response.cs
@@ -6,27 +6,21 @@
  * file 'LICENSE.txt', which is part of this source code package.
  */
 
-using StatePrinting;
-using StatePrinting.OutputFormatters;
+using Newtonsoft.Json;
 
 namespace libfintx.Responses
 {
     public class Response
     {
-        static readonly Stateprinter _printer;
-
         public int TechnicalReturnCode { get; set; }
         public int BusinessReturnCode { get; set; }
         public string ReportText { get; set; }
 
         static Response()
         {
-            _printer = new Stateprinter();
-            //_printer.Configuration.SetNewlineDefinition("");
-            _printer.Configuration.SetIndentIncrement(" ");
-            _printer.Configuration.SetOutputFormatter(new JsonStyle(_printer.Configuration));
+
         }
 
-        public override string ToString() => _printer.PrintObject(this);
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
     }
 }

--- a/src/libfintx/libfintx.csproj
+++ b/src/libfintx/libfintx.csproj
@@ -22,13 +22,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Iconic.Zlib.Netstandard" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.9" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0010" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="5.0.0" />
-    <PackageReference Include="Zlib.Portable" Version="1.11.0" />
   </ItemGroup>
 
 </Project>

--- a/src/libfintx/libfintx.csproj
+++ b/src/libfintx/libfintx.csproj
@@ -22,12 +22,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.9" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.8" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.9" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0010" />
-    <PackageReference Include="StatePrinter" Version="3.0.1" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="5.0.0" />
     <PackageReference Include="Zlib.Portable" Version="1.11.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- Replaced StatePrinters (no full .NET Standard compatibility) with Json.NET for logging
- Replaced zlib package with .NET Standard version
- Removed unnecessary legacy ImageSharp.Core nuget