### PR TITLE
fix main branch build by adding netstandard2.0 as additional framework for EBICS assemblies

### DIFF
--- a/src/libfintx.EBICS/libfintx.EBICS.csproj
+++ b/src/libfintx.EBICS/libfintx.EBICS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libfintx.EBICSConfig/libfintx.EBICSConfig.csproj
+++ b/src/libfintx.EBICSConfig/libfintx.EBICSConfig.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since the last commit [Unterstützung EBICS Signatur A006](https://github.com/iamtorsten/libfintx/commit/086a2837f45f5316a9084e0e44c9a46694ae6c9f) the test build does not work anymore.

With this PR, I will add .NET Standard 2.0 support again to EBICS to make the build work again.